### PR TITLE
feat(cli): add run_async() helper [DEBT-044-A]

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,73 +1,67 @@
 # Kalshi Research Platform — Ralph Wiggum Progress Tracker
 
-**Last Updated:** 2026-01-18
-**Status:** Active (Spec Implementation Queue)
+**Last Updated:** 2026-01-19
+**Status:** Active (Debt Resolution Queue)
 **Purpose:** State file for the Ralph Wiggum loop (see `docs/_ralph-wiggum/protocol.md`)
 
 ---
 
 ## Active Queue
 
-### Phase 1: P1 Specs (Core)
+### Phase 1: P1 Debt (Critical)
 
-#### 1A) Local discovery (independent)
+- [ ] **DEBT-044-A**: Add `run_async()` helper to `cli/utils.py` → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
+- [ ] **DEBT-044-B**: Migrate all CLI modules off direct `asyncio.run()` → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
+- [ ] **DEBT-044-C**: Add `exit_kalshi_api_error()` helper → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
+- [ ] **DEBT-044-D**: Migrate all CLI modules off duplicated `except KalshiAPIError` → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
+- [ ] **DEBT-044-E**: Add DB session helper + migrate CLI DB plumbing → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
 
-- [x] **SPEC-028**: Topic Search & Market Discovery → `docs/_specs/SPEC-028-topic-search-and-discovery.md` [REVIEWED]
-- [x] **SPEC-028-FIX**: Fix FTS5 query crash (TextClause.selectable AttributeError)
+### Phase 2: P2 Debt (High)
 
-#### 1B) Agent stack (depends on SPEC-030)
+- [ ] **DEBT-045-A**: Refactor `agent/research_agent.py:_execute_research_task` (remove noqa) → `docs/_debt/DEBT-045-complexity-noqa-methods.md`
+- [ ] **DEBT-045-B**: Refactor `execution/executor.py:_run_live_checks` (remove noqa) → `docs/_debt/DEBT-045-complexity-noqa-methods.md`
+- [ ] **DEBT-045-C**: Refactor `cli/agent.py:research` (remove noqa) → `docs/_debt/DEBT-045-complexity-noqa-methods.md`
+- [ ] **DEBT-045-D**: Refactor `cli/agent.py:analyze` (remove noqa) → `docs/_debt/DEBT-045-complexity-noqa-methods.md`
+- [ ] **DEBT-045-E**: Refactor `cli/research.py:research_thesis_show` (remove noqa) → `docs/_debt/DEBT-045-complexity-noqa-methods.md`
+- [ ] **DEBT-045-F**: Refactor `cli/scan.py:scan_movers` (remove noqa) → `docs/_debt/DEBT-045-complexity-noqa-methods.md`
 
-- [x] **SPEC-033**: Exa Research Agent → `docs/_specs/SPEC-033-exa-research-agent.md` [REVIEWED]
-- [x] **SPEC-033-FIX**: Add crash recovery for deep research tasks (persist research_id, use list/find reconciliation)
-- [x] **SPEC-032**: Agent System Orchestration → `docs/_specs/SPEC-032-agent-system-orchestration.md` [REVIEWED]
+### Phase 3: P3 Debt (Medium)
 
-### Phase 2: P2 Specs (Optional / When Needed)
+- [ ] **DEBT-046-B**: Migrate CLI modules to use `client_factory` (factory already exists) → `docs/_debt/DEBT-046-dependency-inversion-client-factory.md`
+- [ ] **DEBT-039-A**: Audit `executor.py` broad catches for safety → `docs/_debt/DEBT-039-broad-exception-catches.md`
+- [ ] **DEBT-039-B**: Add exception type logging to all broad catches → `docs/_debt/DEBT-039-broad-exception-catches.md`
+- [ ] **DEBT-047-A**: Introduce constants module + migrate pagination/depth defaults → `docs/_debt/DEBT-047-magic-numbers-policy-constants.md`
+- [ ] **DEBT-047-B**: Migrate scanner/liquidity threshold literals → `docs/_debt/DEBT-047-magic-numbers-policy-constants.md`
 
-- [x] **SPEC-038**: Exa Websets API Coverage → `docs/_specs/SPEC-038-exa-websets-endpoint-coverage.md` [REVIEWED]
-- [x] **SPEC-034**: TradeExecutor Safety Harness (Phase 2 hardening) → `docs/_specs/SPEC-034-trade-executor-safety-harness.md` [REVIEWED]
+### Phase 4: P1 Debt (Large - After Phases 1-3)
 
-### Phase 3: Final Verification
+- [ ] **DEBT-043-A**: Split `cli/research.py` into `cli/research/` package → `docs/_debt/DEBT-043-srp-god-files.md`
+- [ ] **DEBT-043-B**: Split `cli/scan.py` into `cli/scan/` package → `docs/_debt/DEBT-043-srp-god-files.md`
+- [ ] **DEBT-043-C**: Split `api/client.py` into endpoint modules → `docs/_debt/DEBT-043-srp-god-files.md`
 
-- [x] **FINAL-GATES**: All quality gates pass (`pre-commit`, `mypy`, `pytest`, `mkdocs build --strict`)
+### Phase 5: Final Verification
+
+- [ ] **FINAL-GATES**: All quality gates pass (`pre-commit`, `mypy`, `pytest`, `mkdocs build --strict`)
 
 ---
 
 **Guidelines:**
 
-- SPEC-* tasks require a follow-up review iteration and a `[REVIEWED]` marker.
 - Read [`AGENTS.md`](AGENTS.md) first (project intent + safety constraints).
-- Complete SPEC-033 before SPEC-032 (SPEC-032 depends on SPEC-033 for the research provider + shared schemas).
-- SPEC-028 is independent (local DB) and can be implemented anytime.
-- Do not run cost-incurring or irreversible operations during the loop (Exa paid calls, live trading). Prefer unit tests + fixtures.
+- One task per iteration; if a DEBT item is too large for a single safe change, it's already split (e.g., `DEBT-044-A`, `DEBT-044-B`).
+- Avoid cost-incurring or irreversible operations during the loop (paid Exa calls, live trading, live LLM). Prefer unit tests + fixtures.
+- Preserve public API/CLI surfaces; refactors should be mechanical, test-backed, and easy to review/revert.
+- Update the corresponding DEBT-XXX.md acceptance criteria as you complete each sub-task.
 
 ---
 
 ## Work Log
 
-- 2026-01-18: SPEC-034 reviewed and verified. All 4 acceptance criteria confirmed: (1) TradeExecutor enforces dry_run unless live=True, (2) audit logging via finally block for all order attempts, (3) safety checks raise TradeSafetyError before API calls, (4) Phase 2 safety rails fully implemented (fat-finger guard lines 284-288, daily budgets via DailyBudgetTracker lines 263-270, position caps via PositionProvider lines 272-278, liquidity-aware sizing lines 280-323, cancel_order wrapper lines 439-471, amend_order wrapper lines 473-531). Test coverage: 18 unit tests (12 Phase 1 + 6 Phase 2). All Protocol-based providers use dependency injection. Quality gates pass. Implementation complete per spec.
-- 2026-01-18: FINAL-GATES verified - all quality gates pass. pre-commit (all checks including syntax validation, ruff, mypy, pytest) passed. ruff check passed. ruff format verified (245 files). mypy passed (117 source files, no issues). pytest passed (905 tests). mkdocs build --strict passed (documentation built successfully). All Phase 1-3 tasks complete. Ralph Wiggum spec implementation queue complete.
-- 2026-01-18: Implemented SPEC-034 TradeExecutor Phase 2 Safety Rails. Added fat-finger guard (midpoint deviation check), daily budget/loss tracking (max_daily_loss_usd, max_notional_usd), position caps (max_position_contracts), liquidity-aware sizing (slippage limits + grade filters), and order management wrappers (cancel_order, amend_order). All providers use Protocol types for dependency injection. Added 6 Phase 2 unit tests. All quality gates pass (18 execution tests, pre-commit, ruff, mypy, pytest). All acceptance criteria met.
-- 2026-01-18: SPEC-038 reviewed and verified. All acceptance criteria confirmed: (1) ExaWebsetsClient with 9 Phase 1 endpoints implemented, (2) Pydantic models in websets/models.py, (3) golden fixtures in tests/fixtures/golden/exa_websets/ with hand-crafted responses, (4) SSOT validator integration passes all fixtures, (5) 12 unit tests (7 client + 5 fixture validation) all pass, (6) Websets not required by default CLI. Quality gates pass. Implementation complete per spec.
-- 2026-01-18: Implemented SPEC-038 Exa Websets API Coverage (Phase 1). Created ExaWebsetsClient with 9 Phase 1 endpoints (create, preview, get, cancel webset; list/get items; create/get/cancel search). Added Pydantic models (Webset, WebsetItem, WebsetSearch, etc.) with proper datetime handling. Created recording script `scripts/record_exa_websets_responses.py` (requires --yes flag for cost awareness). Generated hand-crafted golden fixtures based on OpenAPI schemas for testing without live API calls. Integrated with SSOT validator. Added 12 unit tests (7 client tests via respx, 5 fixture validation tests). All quality gates pass (pre-commit, ruff, mypy, pytest). All acceptance criteria met.
-- 2026-01-18: SPEC-032 reviewed and verified. All acceptance criteria confirmed: (1) CLI returns valid JSON and handles expected failures, (2) no secret leakage in output, (3) verification failures explicit with VerificationReport, (4) escalation OFF by default (enable_escalation=False), (5) full test coverage (11 verifier tests + 7 orchestrator tests). Quality gates pass. Implementation complete per spec.
-- 2026-01-18: Implemented SPEC-032 Agent System Orchestration (Phase 1). Added AgentKernel orchestrator with deterministic workflow: (1) fetch market + orderbook, (2) gather research via ResearchAgent, (3) synthesize probability via LLM (MockSynthesizer for Phase 1), (4) verify via rule-based checks. Created modules: orchestrator.py, verify.py, providers/kalshi.py, providers/llm.py. Extended schemas.py with MarketInfo, MarketPriceSnapshot, AnalysisResult, VerificationReport, AgentRunResult. Added CLI command `kalshi agent analyze` with JSON/human output modes. Escalation disabled by default (Phase 2). Added 18 unit tests (11 for verifier, 7 for orchestrator). All quality gates pass. All acceptance criteria met.
-- 2026-01-18: SPEC-033-FIX complete - implemented crash recovery for deep research tasks. Added `ResearchTaskState` for JSON-based persistence in `data/agent_state/`. Recovery attempts ID lookup first, falls back to `find_recent_research_task()`. State cleared after completion. Added 10 unit tests (4 for crash recovery, 6 for state management). All quality gates pass. SPEC-033 now [REVIEWED] with all acceptance criteria met.
-- 2026-01-18: SPEC-033 review iteration - found missing crash recovery: research_id is logged but not persisted, no list/find reconciliation for orphaned tasks. Acceptance criterion 5 incomplete. Created SPEC-033-FIX task. Marked SPEC-033 as [NEEDS-FIX].
-- 2026-01-18: Implemented SPEC-033 Exa Research Agent - deterministic plan builder, budget enforcement, crash recovery for deep research tasks, CLI command `kalshi agent research`, 17 unit tests. All quality gates pass.
-- 2026-01-18: Fixed SPEC-028-FIX - replaced text("market_fts") with table() construct to create proper selectable reference. Added test_search_markets_fts5_path() that creates FTS5 tables and exercises the corrected code path. All quality gates pass. SPEC-028 now [REVIEWED].
-- 2026-01-18: SPEC-028 review iteration - found critical bug: FTS5 query crashes with TextClause AttributeError. Tests pass but CLI fails on real DB. Created SPEC-028-FIX task. Marked SPEC-028 as [NEEDS-FIX].
-- 2026-01-18: Implemented SPEC-028 topic search & market discovery (FTS5 virtual tables, SearchRepository, `kalshi market search` CLI command, unit tests). All quality gates pass.
-- 2026-01-18: Implemented SPEC-031 scanner quality profiles (PR #29) and SPEC-030 Exa policy mode/budget controls (PR #30).
-- 2026-01-17: Archived DEBT-029/030/031/032 and cleaned up `_future/` (promoted items to specs).
-- 2026-01-13: Reset PROGRESS.md/PROMPT.md templates (idle queue).
-- 2026-01-10: Fixed portfolio P&L integrity (FIFO realized P&L + unknown handling), updated BUG-056/057, ran `uv run pre-commit run --all-files` and `uv run mkdocs build --strict`
-- 2026-01-10: Skills refactor - created `kalshi-ralph-wiggum` skill, simplified `kalshi-codebase`, enhanced PROMPT.md with SPEC-* self-review protocol, verified SPEC-029/032 against SSOT
-- 2026-01-10: Prep for spec implementation (audited SPEC-028..034, added `kalshi-codebase` skill, updated Ralph prompt/protocol)
-- 2026-01-09: Phase 1-8 complete (all bugs, debt, TODOs resolved)
+- 2026-01-19: Reset PROGRESS.md for debt resolution queue (DEBT-039, 043, 044, 045, 046, 047). Debt docs verified against SSOT. client_factory.py salvaged from prior branch. Starting fresh on all migrations.
 
 ---
 
 ## Completion Criteria
 
 The queue is complete when there are no unchecked items (no lines matching the unchecked-task pattern at column 0).
-The loop operator should verify completion via this file’s state, not by parsing model output.
+The loop operator should verify completion via this file's state, not by parsing model output.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Kalshi Research Platform — Ralph Wiggum Progress Tracker
 
-**Last Updated:** 2026-01-19
+**Last Updated:** 2026-01-20
 **Status:** Active (Debt Resolution Queue)
 **Purpose:** State file for the Ralph Wiggum loop (see `docs/_ralph-wiggum/protocol.md`)
 
@@ -10,7 +10,7 @@
 
 ### Phase 1: P1 Debt (Critical)
 
-- [ ] **DEBT-044-A**: Add `run_async()` helper to `cli/utils.py` → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
+- [x] **DEBT-044-A**: Add `run_async()` helper to `cli/utils.py` → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
 - [ ] **DEBT-044-B**: Migrate all CLI modules off direct `asyncio.run()` → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
 - [ ] **DEBT-044-C**: Add `exit_kalshi_api_error()` helper → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
 - [ ] **DEBT-044-D**: Migrate all CLI modules off duplicated `except KalshiAPIError` → `docs/_debt/DEBT-044-dry-cli-boilerplate.md`
@@ -58,6 +58,7 @@
 ## Work Log
 
 - 2026-01-19: Reset PROGRESS.md for debt resolution queue (DEBT-039, 043, 044, 045, 046, 047). Debt docs verified against SSOT. client_factory.py salvaged from prior branch. Starting fresh on all migrations.
+- 2026-01-20: Implemented DEBT-044-A: added `kalshi_research.cli.utils.run_async()` (centralized `asyncio.run` + Ctrl+C exit 130), migrated `cli/status.py` as the template (3 call sites), added unit tests. Quality gates pass (`uv run pre-commit run --all-files`, `uv run pytest`).
 
 ---
 

--- a/docs/_debt/DEBT-044-dry-cli-boilerplate.md
+++ b/docs/_debt/DEBT-044-dry-cli-boilerplate.md
@@ -12,7 +12,7 @@
 
 The CLI repeats the same patterns dozens of times:
 
-1. **Async wrapper boilerplate** (`asyncio.run(...)`) — 58 copies
+1. **Async wrapper boilerplate** (`asyncio.run(...)`) — 56 copies
 2. **Kalshi API error handling** (`except KalshiAPIError ... Exit(1)`) — 28 copies
 3. **DB session plumbing** (`DatabaseManager(...)` + session creation) — 11 copies
 
@@ -29,9 +29,9 @@ rg -n "except KalshiAPIError" src/kalshi_research/cli | wc -l
 rg -n "DatabaseManager\\(" src/kalshi_research/cli | wc -l
 ```
 
-Current counts (2026-01-19 audit, SSOT verified):
+Current counts (2026-01-20 audit, SSOT verified):
 
-- `asyncio.run`: **58**
+- `asyncio.run`: **56**
 - `except KalshiAPIError`: **28**
 - `DatabaseManager(...)`: **11**
 
@@ -41,7 +41,7 @@ Current counts (2026-01-19 audit, SSOT verified):
 
 Add a single helper (location: `src/kalshi_research/cli/utils.py`):
 
-- `run_async(fn: Callable[[], Awaitable[T]]) -> T`
+- `run_async(coro: Coroutine[object, object, T]) -> T`
 - Enforce consistent cancellation/KeyboardInterrupt handling
 - Avoid per-command nested `_run()` functions
 
@@ -76,10 +76,10 @@ Refactor CLI modules to call these helpers. Migration should be mechanical and t
 
 ## Acceptance Criteria (Phased)
 
-- [ ] Phase A: Add `run_async()` helper and migrate at least one CLI module as a template
+- [x] Phase A: Add `run_async()` helper and migrate at least one CLI module as a template
 - [ ] Phase B: Migrate all CLI modules off direct `asyncio.run()`
 - [ ] Phase C: Add `exit_kalshi_api_error()` helper and migrate at least one CLI module as a template
 - [ ] Phase D: Migrate all CLI modules off duplicated `except KalshiAPIError` blocks
 - [ ] Phase E: Add DB session helper and migrate all CLI DB session setup
 
-**Note (2026-01-19):** This work was implemented on `ralph-wiggum-loop` branch but LOST when that branch was deleted due to conflicts with SPEC-043. Must be redone from scratch.
+**Note (2026-01-20):** Phase A was re-implemented in PR #35 on `ralph-wiggum-loop` after the earlier branch deletion. Phases B–E remain pending.

--- a/src/kalshi_research/cli/status.py
+++ b/src/kalshi_research/cli/status.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from typing import Annotated
 
 import typer
 from rich.table import Table
 
-from kalshi_research.cli.utils import console
+from kalshi_research.cli.utils import console, run_async
 
 app = typer.Typer(help="Exchange status and operational information.")
 
@@ -126,7 +125,7 @@ def status(
             raise typer.Exit(1) from None
         return raw
 
-    payload = asyncio.run(_fetch())
+    payload = run_async(_fetch())
 
     if output_json:
         typer.echo(json.dumps(payload, indent=2, default=str))
@@ -157,7 +156,7 @@ def status_schedule(
 
         return schedule.model_dump(mode="json")
 
-    payload = asyncio.run(_fetch())
+    payload = run_async(_fetch())
 
     if output_json:
         typer.echo(json.dumps(payload, indent=2, default=str))
@@ -188,7 +187,7 @@ def status_announcements(
 
         return announcements.model_dump(mode="json")
 
-    payload = asyncio.run(_fetch())
+    payload = run_async(_fetch())
 
     if output_json:
         typer.echo(json.dumps(payload, indent=2, default=str))

--- a/src/kalshi_research/cli/utils.py
+++ b/src/kalshi_research/cli/utils.py
@@ -22,7 +22,7 @@ T = TypeVar("T")
 def run_async(coro: Coroutine[object, object, T]) -> T:
     """Run a coroutine from a sync CLI command.
 
-    Centralizes asyncio.run() usage across CLI modules to ensure consistent
+    Centralizes `asyncio.run` usage across CLI modules to ensure consistent
     handling of KeyboardInterrupt (Ctrl+C).
 
     Raises:

--- a/src/kalshi_research/cli/utils.py
+++ b/src/kalshi_research/cli/utils.py
@@ -1,14 +1,38 @@
-"""Shared utilities for CLI commands (console output, JSON storage)."""
+"""Shared utilities for CLI commands (console output, JSON storage, async helpers)."""
 
+from __future__ import annotations
+
+import asyncio
 import json
 import uuid
-from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import typer
 from rich.console import Console
 
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+    from pathlib import Path
+
 console = Console()
+
+T = TypeVar("T")
+
+
+def run_async(coro: Coroutine[object, object, T]) -> T:
+    """Run a coroutine from a sync CLI command.
+
+    Centralizes asyncio.run() usage across CLI modules to ensure consistent
+    handling of KeyboardInterrupt (Ctrl+C).
+
+    Raises:
+        typer.Exit: With code 130 on KeyboardInterrupt (standard SIGINT exit code).
+    """
+    try:
+        return asyncio.run(coro)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Interrupted.[/yellow]")
+        raise typer.Exit(130) from None
 
 
 def atomic_write_json(path: Path, data: dict[str, Any]) -> None:

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -1,0 +1,70 @@
+"""Tests for kalshi_research.cli.utils module."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from kalshi_research.cli.utils import run_async
+
+
+class TestRunAsync:
+    """Tests for run_async helper."""
+
+    def test_returns_coroutine_result(self) -> None:
+        """run_async should return the result of the coroutine."""
+
+        async def coro() -> str:
+            return "hello"
+
+        result = run_async(coro())
+        assert result == "hello"
+
+    def test_propagates_exceptions(self) -> None:
+        """run_async should propagate exceptions from the coroutine."""
+
+        async def failing_coro() -> None:
+            raise ValueError("test error")
+
+        with pytest.raises(ValueError, match="test error"):
+            run_async(failing_coro())
+
+    def test_handles_keyboard_interrupt(self) -> None:
+        """run_async should handle KeyboardInterrupt and exit with code 130."""
+
+        async def interrupted_coro() -> None:
+            raise KeyboardInterrupt
+
+        with pytest.raises(typer.Exit) as exc_info:
+            run_async(interrupted_coro())
+
+        assert exc_info.value.exit_code == 130
+
+    def test_prints_interrupted_message_on_ctrl_c(self) -> None:
+        """run_async should print 'Interrupted' on KeyboardInterrupt."""
+
+        async def interrupted_coro() -> None:
+            raise KeyboardInterrupt
+
+        with (
+            patch("kalshi_research.cli.utils.console.print") as mock_print,
+            pytest.raises(typer.Exit),
+        ):
+            run_async(interrupted_coro())
+
+        mock_print.assert_called_once()
+        call_args = mock_print.call_args[0][0]
+        assert "Interrupted" in call_args
+
+    def test_async_operations_work(self) -> None:
+        """run_async should properly execute async operations."""
+
+        async def async_op() -> int:
+            await asyncio.sleep(0.001)  # Tiny sleep to verify async works
+            return 42
+
+        result = run_async(async_op())
+        assert result == 42


### PR DESCRIPTION
## Summary
- Add `run_async()` helper to `cli/utils.py` for centralized async execution
- Consistent KeyboardInterrupt handling (exit code 130, standard SIGINT)
- Migrate `status.py` as template implementation (3 asyncio.run() calls replaced)
- Add 5 unit tests for the new helper

## Test plan
- [x] Unit tests pass (`pytest tests/unit/cli/test_utils.py`)
- [x] Pre-commit hooks pass
- [x] Mypy type checking passes

## Related
Part of DEBT-044: DRY CLI boilerplate reduction (`docs/_debt/DEBT-044-dry-cli-boilerplate.md`)

This is Phase A of DEBT-044. Subsequent phases will migrate remaining CLI modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated progress tracking documentation with reorganized phases and tasks focused on debt resolution priorities.

* **Refactor**
  * Streamlined CLI command execution pattern for improved consistency across commands.

* **Tests**
  * Added comprehensive test coverage for CLI utility functions, including error handling and interrupt scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->